### PR TITLE
Remove an unused struct and use cmp.Or

### DIFF
--- a/internal/processors/signalconvert/signalconvert.go
+++ b/internal/processors/signalconvert/signalconvert.go
@@ -99,22 +99,11 @@ func (v *vssProcessor) processMsg(ctx context.Context, msg *service.Message) ser
 	return retBatch
 }
 
-type LatLngIdx struct {
-	Latitude  *int `json:"latitude"`
-	Longitude *int `json:"longitude"`
-}
-
 // pruneSignals removes signals that are not valid and returns an error for each invalid signal.
 func pruneSignals(signals []vss.Signal) ([]vss.Signal, error) {
 	var errs error
 	slices.SortFunc(signals, func(a, b vss.Signal) int {
-		if a.Timestamp.Before(b.Timestamp) {
-			return -1
-		}
-		if a.Timestamp.After(b.Timestamp) {
-			return 1
-		}
-		return cmp.Compare(a.Name, b.Name)
+		return cmp.Or(a.Timestamp.Compare(b.Timestamp), cmp.Compare(a.Name, b.Name))
 	})
 	lastCord := -1
 	for i := range signals {


### PR DESCRIPTION
I was poking around in here and noticed that

1. This `LatLngIdx` struct isn't used anymore. I think it used to be part of `pruneSignals`.
2. We seem to be dictionary ordering signals by timestamp and then name, and the [new-ish `cmp.Or`](https://pkg.go.dev/cmp#Or) is great for this.

None of this is urgent or important.