### PR TITLE
Fix large attestation payloads dropped by document buffer

### DIFF
--- a/charts/dis/files/streams/output-document.yaml
+++ b/charts/dis/files/streams/output-document.yaml
@@ -3,7 +3,7 @@ input:
 
 buffer:
   memory:
-    limit: 10485760
+    limit: 52428800
 
 pipeline:
   processors:


### PR DESCRIPTION
## Summary
- The document stream memory buffer was set to 10MB, but large attestation payloads (e.g. PDF invoices at ~14MB) exceed this limit and get silently dropped
- This prevents the S3 upload and ClickHouse `cloud_event` index row from being created for large documents
- Increases the buffer from 10MB to 50MB to accommodate large document attestations

## Test plan
- [ ] Submit a `dimo.raw.vehicle.service.invoice` attestation with a ~14MB PDF payload
- [ ] Verify the document is uploaded to S3 at the expected `cloudevent/blobs/` path
- [ ] Verify the corresponding `cloud_event` row is created in ClickHouse