### PR TITLE
fix: checksum contract addresses in decoded DIDs

### DIFF
--- a/internal/processors/cloudeventconvert/attesation_msg.go
+++ b/internal/processors/cloudeventconvert/attesation_msg.go
@@ -46,6 +46,12 @@ func (c *cloudeventProcessor) processAttestationMsg(ctx context.Context, msg *se
 	return service.MessageBatch{msg}
 }
 
+// parseAndValidateAttestation unmarshals an attestation cloud event and
+// validates it. It rewrites Subject and Source on the returned event so
+// any contract or account address is in EIP-55 checksum form: a
+// lowercased / mixed-case `did:erc721:` or `did:ethr:` Subject is
+// re-serialized via DID.String(), and Source is normalized via
+// common.HexToAddress(...).Hex() for consistent downstream storage.
 func parseAndValidateAttestation(msgBytes []byte, source string) (*cloudevent.RawEvent, error) {
 	var event cloudevent.RawEvent
 	if err := json.Unmarshal(msgBytes, &event); err != nil {

--- a/internal/processors/cloudeventconvert/attesation_msg.go
+++ b/internal/processors/cloudeventconvert/attesation_msg.go
@@ -56,10 +56,12 @@ func parseAndValidateAttestation(msgBytes []byte, source string) (*cloudevent.Ra
 		return nil, fmt.Errorf("event timestamp %v exceeds valid range", event.Time)
 	}
 
-	if _, err := cloudevent.DecodeERC721DID(event.Subject); err != nil {
-		if _, err := cloudevent.DecodeEthrDID(event.Subject); err != nil {
-			return nil, fmt.Errorf("invalid attestation subject format: %w", err)
-		}
+	if did, err := cloudevent.DecodeERC721DID(event.Subject); err == nil {
+		event.Subject = did.String()
+	} else if did, err := cloudevent.DecodeEthrDID(event.Subject); err == nil {
+		event.Subject = did.String()
+	} else {
+		return nil, fmt.Errorf("invalid attestation subject format: %w", err)
 	}
 
 	// If the payload includes a source, use it (delegation support);

--- a/internal/processors/cloudeventconvert/checksum_test.go
+++ b/internal/processors/cloudeventconvert/checksum_test.go
@@ -1,0 +1,143 @@
+package cloudeventconvert
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/DIMO-Network/cloudevent"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	checksumAddr = "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d"
+	lowerAddr    = "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+)
+
+func TestIsValidConnectionHeader_ChecksumsAddresses(t *testing.T) {
+	logger := service.MockResources().Logger()
+
+	tests := []struct {
+		name             string
+		hdr              cloudevent.CloudEventHeader
+		expectedSubject  string
+		expectedProducer string
+		expectedSource   string
+	}{
+		{
+			name: "lowercased erc721 DID is rewritten to checksum",
+			hdr: cloudevent.CloudEventHeader{
+				Subject:  "did:erc721:1:" + lowerAddr + ":2",
+				Producer: "did:erc721:1:" + lowerAddr + ":1",
+				Source:   lowerAddr,
+			},
+			expectedSubject:  "did:erc721:1:" + checksumAddr + ":2",
+			expectedProducer: "did:erc721:1:" + checksumAddr + ":1",
+			expectedSource:   checksumAddr,
+		},
+		{
+			name: "already-checksummed erc721 DID is unchanged",
+			hdr: cloudevent.CloudEventHeader{
+				Subject:  "did:erc721:1:" + checksumAddr + ":2",
+				Producer: "did:erc721:1:" + checksumAddr + ":1",
+				Source:   checksumAddr,
+			},
+			expectedSubject:  "did:erc721:1:" + checksumAddr + ":2",
+			expectedProducer: "did:erc721:1:" + checksumAddr + ":1",
+			expectedSource:   checksumAddr,
+		},
+		{
+			name: "legacy nft DID with lowercased address is rewritten to checksummed erc721",
+			hdr: cloudevent.CloudEventHeader{
+				Subject:  "did:nft:1:" + lowerAddr + "_2",
+				Producer: "did:nft:1:" + lowerAddr + "_1",
+				Source:   lowerAddr,
+			},
+			expectedSubject:  "did:erc721:1:" + checksumAddr + ":2",
+			expectedProducer: "did:erc721:1:" + checksumAddr + ":1",
+			expectedSource:   checksumAddr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hdr := tt.hdr
+			require.True(t, isValidConnectionHeader(&hdr, logger))
+			assert.Equal(t, tt.expectedSubject, hdr.Subject)
+			assert.Equal(t, tt.expectedProducer, hdr.Producer)
+			assert.Equal(t, tt.expectedSource, hdr.Source)
+		})
+	}
+}
+
+func TestParseAndValidateAttestation_ChecksumsSubjectAndSource(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	tests := []struct {
+		name            string
+		event           cloudevent.CloudEventHeader
+		callerSource    string
+		expectedSubject string
+		expectedSource  string
+	}{
+		{
+			name: "lowercased erc721 subject is rewritten to checksum",
+			event: cloudevent.CloudEventHeader{
+				ID:          "id-1",
+				SpecVersion: "1.0",
+				Source:      lowerAddr,
+				Producer:    lowerAddr,
+				Subject:     "did:erc721:1:" + lowerAddr + ":1005",
+				Type:        cloudevent.TypeAttestation,
+				Time:        now,
+			},
+			callerSource:    lowerAddr,
+			expectedSubject: "did:erc721:1:" + checksumAddr + ":1005",
+			expectedSource:  checksumAddr,
+		},
+		{
+			name: "lowercased ethr subject is rewritten to checksum",
+			event: cloudevent.CloudEventHeader{
+				ID:          "id-2",
+				SpecVersion: "1.0",
+				Source:      lowerAddr,
+				Producer:    lowerAddr,
+				Subject:     "did:ethr:1:" + lowerAddr,
+				Type:        cloudevent.TypeAttestation,
+				Time:        now,
+			},
+			callerSource:    lowerAddr,
+			expectedSubject: "did:ethr:1:" + checksumAddr,
+			expectedSource:  checksumAddr,
+		},
+		{
+			name: "lowercased caller source falls back when payload source is empty",
+			event: cloudevent.CloudEventHeader{
+				ID:          "id-3",
+				SpecVersion: "1.0",
+				Producer:    lowerAddr,
+				Subject:     "did:erc721:1:" + lowerAddr + ":1",
+				Type:        cloudevent.TypeAttestation,
+				Time:        now,
+			},
+			callerSource:    lowerAddr,
+			expectedSubject: "did:erc721:1:" + checksumAddr + ":1",
+			expectedSource:  checksumAddr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := cloudevent.RawEvent{CloudEventHeader: tt.event, Data: json.RawMessage(`{}`)}
+			msgBytes, err := json.Marshal(raw)
+			require.NoError(t, err)
+
+			got, err := parseAndValidateAttestation(msgBytes, tt.callerSource)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedSubject, got.Subject)
+			assert.Equal(t, tt.expectedSource, got.Source)
+		})
+	}
+}

--- a/internal/processors/cloudeventconvert/connection_msg.go
+++ b/internal/processors/cloudeventconvert/connection_msg.go
@@ -90,6 +90,12 @@ func setConnectionContentType(eventHdr *cloudevent.CloudEventHeader, msg *servic
 	msg.MetaSetMut(processors.MessageContentKey, cloudEventValidContentType)
 }
 
+// isValidConnectionHeader validates a connection cloud event header and
+// rewrites Subject, Producer, and Source in place so that any contract or
+// account address is in EIP-55 checksum form. Lowercased / mixed-case
+// addresses are accepted on input but normalized before being passed
+// downstream (metadata, ClickHouse, Kafka, Parquet). Legacy `did:nft:`
+// values are also rewritten to their canonical `did:erc721:` form.
 func isValidConnectionHeader(eventHdr *cloudevent.CloudEventHeader, logger *service.Logger) bool {
 	if did, err := cloudevent.DecodeERC721DID(eventHdr.Subject); err == nil {
 		eventHdr.Subject = did.String()

--- a/internal/processors/cloudeventconvert/connection_msg.go
+++ b/internal/processors/cloudeventconvert/connection_msg.go
@@ -91,7 +91,9 @@ func setConnectionContentType(eventHdr *cloudevent.CloudEventHeader, msg *servic
 }
 
 func isValidConnectionHeader(eventHdr *cloudevent.CloudEventHeader, logger *service.Logger) bool {
-	if _, err := cloudevent.DecodeERC721DID(eventHdr.Subject); err != nil {
+	if did, err := cloudevent.DecodeERC721DID(eventHdr.Subject); err == nil {
+		eventHdr.Subject = did.String()
+	} else {
 		did, err := cloudevent.DecodeLegacyNFTDID(eventHdr.Subject)
 		if err != nil {
 			return false
@@ -100,7 +102,9 @@ func isValidConnectionHeader(eventHdr *cloudevent.CloudEventHeader, logger *serv
 		logger.Debugf("Cloud event header subject for source %s is a legacy NFT DID: %v", eventHdr.Source, eventHdr)
 	}
 
-	if _, err := cloudevent.DecodeERC721DID(eventHdr.Producer); err != nil {
+	if did, err := cloudevent.DecodeERC721DID(eventHdr.Producer); err == nil {
+		eventHdr.Producer = did.String()
+	} else {
 		did, err := cloudevent.DecodeLegacyNFTDID(eventHdr.Producer)
 		if err != nil {
 			return false
@@ -109,7 +113,11 @@ func isValidConnectionHeader(eventHdr *cloudevent.CloudEventHeader, logger *serv
 		logger.Debugf("Cloud event header producer for source %s is a legacy NFT DID: %v", eventHdr.Source, eventHdr)
 	}
 
-	return common.IsHexAddress(eventHdr.Source)
+	if !common.IsHexAddress(eventHdr.Source) {
+		return false
+	}
+	eventHdr.Source = common.HexToAddress(eventHdr.Source).Hex()
+	return true
 }
 
 func isValidConnectionType(eventHdr *cloudevent.CloudEventHeader) bool {


### PR DESCRIPTION
## Summary
- Re-serialize ERC721 / Ethr / Legacy NFT DIDs after decoding so a lowercased contract address received in CloudEvent `Subject`/`Producer` is normalized to EIP-55 checksum (via `common.Address.Hex()`).
- Also normalize CloudEvent `Source` (connection path) to checksummed form.
- `common.HexToAddress` is case-insensitive, so decoding previously succeeded but the raw lowercased string was passed downstream unchanged into metadata, ClickHouse, Kafka, and Parquet.

Touches:
- `internal/processors/cloudeventconvert/connection_msg.go` — `isValidConnectionHeader`
- `internal/processors/cloudeventconvert/attesation_msg.go` — `parseAndValidateAttestation`

Ref: https://github.com/DIMO-Network/cloudevent/blob/36983ae80aa63d2325d1b352dca56266050349e8/did.go#L49

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/processors/cloudeventconvert/...`
- [ ] `make test-benthos` after `make build`
- [ ] Spot-check downstream sinks (ClickHouse / Kafka / Parquet) receive checksummed addresses when input DID is lowercased