### PR TITLE
Cap CloudEvent header size at 8 KiB

### DIFF
--- a/internal/processors/cloudeventconvert/cloudeventconvert.go
+++ b/internal/processors/cloudeventconvert/cloudeventconvert.go
@@ -30,8 +30,10 @@ const (
 	cloudEventValidContentType = "dimo_valid_cloudevent"
 
 	// MaxHeaderBytes caps the JSON-serialized size of a CloudEvent header
-	// (every field except data and data_base64). Prevents unbounded Tags or
-	// Extras from ballooning ClickHouse rows and Parquet columns downstream.
+	// (every field except data and data_base64). No individual header field
+	// has its own length limit, so without this any string field, Tags entry,
+	// or Extras value could balloon ClickHouse rows and Parquet columns
+	// downstream.
 	MaxHeaderBytes = 8 * 1024
 )
 

--- a/internal/processors/cloudeventconvert/cloudeventconvert.go
+++ b/internal/processors/cloudeventconvert/cloudeventconvert.go
@@ -2,6 +2,7 @@ package cloudeventconvert
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -27,6 +28,11 @@ const (
 	cloudEventIDKey = "dimo_cloudevent_id"
 
 	cloudEventValidContentType = "dimo_valid_cloudevent"
+
+	// MaxHeaderBytes caps the JSON-serialized size of a CloudEvent header
+	// (every field except data and data_base64). Prevents unbounded Tags or
+	// Extras from ballooning ClickHouse rows and Parquet columns downstream.
+	MaxHeaderBytes = 8 * 1024
 )
 
 var erc1271magicValue = [4]byte{0x16, 0x26, 0xba, 0x7e}
@@ -162,6 +168,14 @@ func validateHeadersAndSetDefaults(event *cloudevent.CloudEventHeader, source, d
 	}
 	if event.Producer != "" && !ValidIdentifier(event.Producer) {
 		return fmt.Errorf("invalid producer: %s", event.Producer)
+	}
+
+	b, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal header for size check: %w", err)
+	}
+	if len(b) > MaxHeaderBytes {
+		return fmt.Errorf("header size %d exceeds max %d", len(b), MaxHeaderBytes)
 	}
 
 	return nil

--- a/internal/processors/cloudeventconvert/cloudeventconvert.go
+++ b/internal/processors/cloudeventconvert/cloudeventconvert.go
@@ -25,7 +25,7 @@ const (
 	cloudEventTypeKey     = "dimo_cloudevent_type"
 	cloudEventProducerKey = "dimo_cloudevent_producer"
 	cloudEventSubjectKey  = "dimo_cloudevent_subject"
-	cloudEventIDKey = "dimo_cloudevent_id"
+	cloudEventIDKey       = "dimo_cloudevent_id"
 
 	cloudEventValidContentType = "dimo_valid_cloudevent"
 

--- a/internal/processors/cloudeventconvert/cloudeventconvert_test.go
+++ b/internal/processors/cloudeventconvert/cloudeventconvert_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -305,6 +306,102 @@ func TestProcessBatch(t *testing.T) {
 			msgLen:        1,
 			expectedError: true,
 			expectedMeta:  nil,
+		},
+		{
+			name:           "connection header with oversized Tags exceeds size cap",
+			inputData:      []byte(`{"test": "data"}`),
+			sourceID:       common.HexToAddress("0x").String(),
+			messageContent: httpinputserver.ConnectionContent,
+			setupMock: func() *mockCloudEventModule {
+				event := cloudevent.CloudEventHeader{
+					ID:       "33",
+					Type:     cloudevent.TypeStatus,
+					Producer: "did:erc721:1:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d:1",
+					Subject:  "did:erc721:1:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d:2",
+					Time:     timestamp,
+					Tags:     []string{strings.Repeat("x", MaxHeaderBytes+1)},
+				}
+				return &mockCloudEventModule{
+					hdrs: []cloudevent.CloudEventHeader{event},
+					data: json.RawMessage(`{"key": "value"}`),
+					err:  nil,
+				}
+			},
+			msgLen:        1,
+			expectedError: true,
+			expectedMeta:  nil,
+		},
+		{
+			name:           "connection header with many small Tags totaling above cap",
+			inputData:      []byte(`{"test": "data"}`),
+			sourceID:       common.HexToAddress("0x").String(),
+			messageContent: httpinputserver.ConnectionContent,
+			setupMock: func() *mockCloudEventModule {
+				tags := make([]string, 1000)
+				for i := range tags {
+					tags[i] = strings.Repeat("a", 16)
+				}
+				event := cloudevent.CloudEventHeader{
+					ID:       "33",
+					Type:     cloudevent.TypeStatus,
+					Producer: "did:erc721:1:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d:1",
+					Subject:  "did:erc721:1:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d:2",
+					Time:     timestamp,
+					Tags:     tags,
+				}
+				return &mockCloudEventModule{
+					hdrs: []cloudevent.CloudEventHeader{event},
+					data: json.RawMessage(`{"key": "value"}`),
+					err:  nil,
+				}
+			},
+			msgLen:        1,
+			expectedError: true,
+			expectedMeta:  nil,
+		},
+		{
+			name: "attestation with oversized Extras exceeds size cap",
+			inputData: []byte(fmt.Sprintf(
+				`{"id":"unique-attestation-id-1","source":"0x07B584f6a7125491C991ca2a45ab9e641B1CeE1b","producer":"0x07B584f6a7125491C991ca2a45ab9e641B1CeE1b","specversion":"1.0","subject":"did:erc721:80002:0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8:1005","time":"%s","type":"dimo.attestation","signature":"0xa2f41b51853db03749da01976aaef503252c3e240e4edb3c5651856c7b4842fa54be0cb843ee380561f5583ed7b38c99f8db6f3d3aa345856449e85be6e29af91b","junk":"%s","data":{"x":1}}`,
+				attestationTimestamp.Format(time.RFC3339),
+				strings.Repeat("z", MaxHeaderBytes+1),
+			)),
+			sourceID:       common.HexToAddress("0x07B584f6a7125491C991ca2a45ab9e641B1CeE1b").String(),
+			messageContent: httpinputserver.AttestationContent,
+			setupMock: func() *mockCloudEventModule {
+				return &mockCloudEventModule{}
+			},
+			msgLen:        1,
+			expectedError: true,
+			expectedMeta:  nil,
+		},
+		{
+			name:           "connection header with Tags just under size cap succeeds",
+			inputData:      []byte(`{"test": "data"}`),
+			sourceID:       common.HexToAddress("0x").String(),
+			messageContent: httpinputserver.ConnectionContent,
+			setupMock: func() *mockCloudEventModule {
+				// Aim for ~7 KiB of tag content; well under the 8 KiB cap.
+				event := cloudevent.CloudEventHeader{
+					ID:       "33",
+					Type:     cloudevent.TypeStatus,
+					Producer: "did:erc721:1:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d:1",
+					Subject:  "did:erc721:1:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d:2",
+					Time:     timestamp,
+					Tags:     []string{strings.Repeat("y", 7000)},
+				}
+				return &mockCloudEventModule{
+					hdrs: []cloudevent.CloudEventHeader{event},
+					data: json.RawMessage(`{"key": "value"}`),
+					err:  nil,
+				}
+			},
+			msgLen:        1,
+			expectedError: false,
+			expectedMeta: map[string]any{
+				cloudEventTypeKey:            cloudevent.TypeStatus,
+				processors.MessageContentKey: "dimo_valid_cloudevent",
+			},
 		},
 		{
 			name:           "attestation with invalid type",

--- a/tests/integration/error_test.go
+++ b/tests/integration/error_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +60,47 @@ func TestUnsupportedCloudEventType(t *testing.T) {
 	// Verify no signals appeared for this subject
 	msgs := consumeKafka(t, "topic.device.signals", startOffset, 5*time.Second)
 	require.Empty(t, msgs, "unsupported CloudEvent type should not produce signals")
+}
+
+func TestOversizedHeaderRejected(t *testing.T) {
+	subject := "did:erc721:137:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:777"
+
+	payload := map[string]any{
+		"id":             "test-oversized-header",
+		"source":         "will-be-overwritten",
+		"dataschema":     "testschema/v2.0",
+		"subject":        subject,
+		"producer":       subject,
+		"type":           "dimo.status",
+		"time":           "2024-04-18T17:20:46.436008782Z",
+		"vehicleTokenId": 777,
+		// Top-level junk key lands in CloudEventHeader.Extras and pushes the
+		// JSON-serialized header above MaxHeaderBytes (8 KiB).
+		"junk": strings.Repeat("z", 9*1024),
+		"data": map[string]any{
+			"timestamp": 1713460846435,
+			"signals": []map[string]any{
+				{
+					"timestamp": "2024-04-18T17:20:26.633Z",
+					"name":      "powertrainCombustionEngineECT",
+					"value":     90,
+				},
+			},
+		},
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	startOffset := kafkaEndOffset(t, "topic.device.signals")
+
+	resp := postMTLS(t, payloadBytes)
+	drainAndClose(t, resp)
+
+	time.Sleep(750 * time.Millisecond)
+
+	msgs := consumeKafka(t, "topic.device.signals", startOffset, 5*time.Second)
+	require.Empty(t, msgs, "oversized header should be rejected before any signal is produced")
 }
 
 func TestEmptyPayload(t *testing.T) {


### PR DESCRIPTION
We're storing big files on their own in S3, outside of Parquet, but headers that still go into Parquet and ClickHouse could in principle be very large. This would likely be malicious usage.