### PR TITLE
Add a whitelist for content types

### DIFF
--- a/internal/processors/cloudeventconvert/attesation_msg.go
+++ b/internal/processors/cloudeventconvert/attesation_msg.go
@@ -74,7 +74,7 @@ func parseAndValidateAttestation(msgBytes []byte, source string) (*cloudevent.Ra
 	// Normalize to EIP-55 checksummed form for consistent storage.
 	resolvedSource = common.HexToAddress(resolvedSource).Hex()
 
-	if err := validateHeadersAndSetDefaults(&event.CloudEventHeader, resolvedSource, ksuid.New().String()); err != nil {
+	if err := validateHeadersAndSetDefaults(&event.CloudEventHeader, resolvedSource, ksuid.New().String(), event.DataBase64 != ""); err != nil {
 		return nil, fmt.Errorf("failed to validate headers: %w", err)
 	}
 

--- a/internal/processors/cloudeventconvert/cloudeventconvert.go
+++ b/internal/processors/cloudeventconvert/cloudeventconvert.go
@@ -32,6 +32,14 @@ const (
 var erc1271magicValue = [4]byte{0x16, 0x26, 0xba, 0x7e}
 var validCharacters = regexp.MustCompile(`^[a-zA-Z0-9\-_/,. :]+$`)
 
+// allowedContentTypes is the whitelist of MIME types accepted for cloud event data.
+var allowedContentTypes = map[string]struct{}{
+	"application/json": {},
+	"image/png":        {},
+	"image/jpeg":       {},
+	"application/pdf":  {},
+}
+
 type cloudeventProcessor struct {
 	logger          *service.Logger
 	producerLoggers map[string]*ratedlogger.Logger
@@ -118,7 +126,10 @@ func (c *cloudeventProcessor) processMsg(ctx context.Context, msg *service.Messa
 	}
 }
 
-func validateHeadersAndSetDefaults(event *cloudevent.CloudEventHeader, source, defaultID string) error {
+// validateHeadersAndSetDefaults validates the cloud event header and fills in defaults.
+// isBase64 indicates whether the event payload arrived as data_base64 rather than data;
+// it controls how the data content type is defaulted and validated.
+func validateHeadersAndSetDefaults(event *cloudevent.CloudEventHeader, source, defaultID string, isBase64 bool) error {
 	event.Source = source
 
 	if event.Subject == "" {
@@ -135,8 +146,8 @@ func validateHeadersAndSetDefaults(event *cloudevent.CloudEventHeader, source, d
 	if event.SpecVersion == "" {
 		event.SpecVersion = "1.0"
 	}
-	if event.DataContentType == "" {
-		event.DataContentType = "application/json"
+	if err := validateAndSetContentType(event, isBase64); err != nil {
+		return err
 	}
 
 	if !ValidIdentifier(event.ID) {
@@ -177,4 +188,28 @@ func setMetaData(hdr *cloudevent.CloudEventHeader, msg *service.Message) {
 
 func ValidIdentifier(str string) bool {
 	return validCharacters.MatchString(str)
+}
+
+// validateAndSetContentType applies the content type rules to the event header.
+//   - If the event uses data_base64, datacontenttype must be set explicitly.
+//   - Otherwise the data field is treated as JSON: an empty value is defaulted to
+//     application/json and any other value is rejected.
+//   - In all cases, datacontenttype must be one of the whitelisted MIME types.
+func validateAndSetContentType(event *cloudevent.CloudEventHeader, isBase64 bool) error {
+	if isBase64 {
+		if event.DataContentType == "" {
+			return errors.New("datacontenttype is required for data_base64 events")
+		}
+	} else {
+		if event.DataContentType == "" {
+			event.DataContentType = "application/json"
+		}
+		if event.DataContentType != "application/json" {
+			return fmt.Errorf("datacontenttype %q is not allowed for data events: must be application/json", event.DataContentType)
+		}
+	}
+	if _, ok := allowedContentTypes[event.DataContentType]; !ok {
+		return fmt.Errorf("datacontenttype %q is not in the allowed list", event.DataContentType)
+	}
+	return nil
 }

--- a/internal/processors/cloudeventconvert/cloudeventconvert.go
+++ b/internal/processors/cloudeventconvert/cloudeventconvert.go
@@ -24,7 +24,7 @@ const (
 	cloudEventTypeKey     = "dimo_cloudevent_type"
 	cloudEventProducerKey = "dimo_cloudevent_producer"
 	cloudEventSubjectKey  = "dimo_cloudevent_subject"
-	cloudEventIDKey = "dimo_cloudevent_id"
+	cloudEventIDKey       = "dimo_cloudevent_id"
 
 	cloudEventValidContentType = "dimo_valid_cloudevent"
 )
@@ -32,7 +32,7 @@ const (
 var erc1271magicValue = [4]byte{0x16, 0x26, 0xba, 0x7e}
 var validCharacters = regexp.MustCompile(`^[a-zA-Z0-9\-_/,. :]+$`)
 
-// allowedContentTypes is the whitelist of MIME types accepted for cloud event data.
+// allowedContentTypes is the whitelist of MIME types accepted for CloudEvent data.
 var allowedContentTypes = map[string]struct{}{
 	"application/json": {},
 	"image/png":        {},

--- a/internal/processors/cloudeventconvert/cloudeventconvert_test.go
+++ b/internal/processors/cloudeventconvert/cloudeventconvert_test.go
@@ -362,3 +362,136 @@ func TestProcessBatch(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAndSetContentType(t *testing.T) {
+	tests := []struct {
+		name                    string
+		inputContentType        string
+		isBase64                bool
+		expectedContentType     string
+		expectError             bool
+	}{
+		{
+			name:                "data event empty defaults to application/json",
+			inputContentType:    "",
+			isBase64:            false,
+			expectedContentType: "application/json",
+		},
+		{
+			name:                "data event with application/json passes",
+			inputContentType:    "application/json",
+			isBase64:            false,
+			expectedContentType: "application/json",
+		},
+		{
+			name:             "data event with image/png is rejected",
+			inputContentType: "image/png",
+			isBase64:         false,
+			expectError:      true,
+		},
+		{
+			name:             "data event with arbitrary type is rejected",
+			inputContentType: "text/plain",
+			isBase64:         false,
+			expectError:      true,
+		},
+		{
+			name:             "data_base64 event with empty content type is rejected",
+			inputContentType: "",
+			isBase64:         true,
+			expectError:      true,
+		},
+		{
+			name:                "data_base64 event with image/png passes",
+			inputContentType:    "image/png",
+			isBase64:            true,
+			expectedContentType: "image/png",
+		},
+		{
+			name:                "data_base64 event with image/jpeg passes",
+			inputContentType:    "image/jpeg",
+			isBase64:            true,
+			expectedContentType: "image/jpeg",
+		},
+		{
+			name:                "data_base64 event with application/pdf passes",
+			inputContentType:    "application/pdf",
+			isBase64:            true,
+			expectedContentType: "application/pdf",
+		},
+		{
+			name:                "data_base64 event with application/json passes",
+			inputContentType:    "application/json",
+			isBase64:            true,
+			expectedContentType: "application/json",
+		},
+		{
+			name:             "data_base64 event with non-whitelisted type is rejected",
+			inputContentType: "text/plain",
+			isBase64:         true,
+			expectError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hdr := &cloudevent.CloudEventHeader{DataContentType: tt.inputContentType}
+			err := validateAndSetContentType(hdr, tt.isBase64)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedContentType, hdr.DataContentType)
+		})
+	}
+}
+
+func TestParseAndValidateAttestationContentType(t *testing.T) {
+	source := common.HexToAddress("0x07B584f6a7125491C991ca2a45ab9e641B1CeE1b").String()
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	baseFields := func(extra string) []byte {
+		return []byte(fmt.Sprintf(`{"id":"id1","source":"%s","producer":"%s","specversion":"1.0","subject":"did:erc721:80002:0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8:1005","time":"%s","type":"dimo.attestation","signature":"0xdeadbeef"%s}`, source, source, timestamp, extra))
+	}
+
+	tests := []struct {
+		name        string
+		input       []byte
+		expectError bool
+	}{
+		{
+			name:  "data event with no datacontenttype defaults to json",
+			input: baseFields(`,"data":{"k":"v"}`),
+		},
+		{
+			name:        "data event with image/png is rejected",
+			input:       baseFields(`,"data":{"k":"v"},"datacontenttype":"image/png"`),
+			expectError: true,
+		},
+		{
+			name:  "data_base64 event with image/png is accepted",
+			input: baseFields(`,"data_base64":"aGVsbG8=","datacontenttype":"image/png"`),
+		},
+		{
+			name:        "data_base64 event without datacontenttype is rejected",
+			input:       baseFields(`,"data_base64":"aGVsbG8="`),
+			expectError: true,
+		},
+		{
+			name:        "data_base64 event with non-whitelisted type is rejected",
+			input:       baseFields(`,"data_base64":"aGVsbG8=","datacontenttype":"text/plain"`),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseAndValidateAttestation(tt.input, source)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/processors/cloudeventconvert/connection_msg.go
+++ b/internal/processors/cloudeventconvert/connection_msg.go
@@ -63,7 +63,7 @@ func (c *cloudeventProcessor) createConnectionMsgs(origMsg *service.Message, sou
 			logger.Warnf("Cloud event time is in the future: now() = %v is before event.time = %v \n %+v", time.Now(), hdrs[i].Time, hdrs[i])
 		}
 		newMsg := origMsg.Copy()
-		if err := validateHeadersAndSetDefaults(hdr, source, defaultID); err != nil {
+		if err := validateHeadersAndSetDefaults(hdr, source, defaultID, false); err != nil {
 			return nil, fmt.Errorf("invalid cloud event header string: %w", err)
 		}
 		if !isValidConnectionType(hdr) {


### PR DESCRIPTION
Currently we allow JSON, JPEG, PNG, and PDF. If you're providing a data field then you must specify JSON if you specify anything.