### PR TITLE
Handle tombstone events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/redpanda-data/benthos/v4 => github.com/DIMO-Network/benthos/v
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/DIMO-Network/clickhouse-infra v0.0.8
-	github.com/DIMO-Network/cloudevent v0.2.9-0.20260429154543-207c0df87d44 // Update to a real tag before merge.
+	github.com/DIMO-Network/cloudevent v0.2.9
 	github.com/DIMO-Network/model-garage v1.0.11
 	github.com/DIMO-Network/shared v1.0.7
 	github.com/MicahParks/keyfunc/v3 v3.6.1

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,10 @@ go 1.25.0
 
 replace github.com/redpanda-data/benthos/v4 => github.com/DIMO-Network/benthos/v4 v4.0.0-20250911163055-af824a0c7e26
 
-// temporary for local testing: replace github.com/DIMO-Network/model-garage => ../model-garage
-
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/DIMO-Network/clickhouse-infra v0.0.8
-	github.com/DIMO-Network/cloudevent v0.2.8
+	github.com/DIMO-Network/cloudevent v0.2.9-0.20260429154543-207c0df87d44 // Update to a real tag before merge.
 	github.com/DIMO-Network/model-garage v1.0.11
 	github.com/DIMO-Network/shared v1.0.7
 	github.com/MicahParks/keyfunc/v3 v3.6.1

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/DIMO-Network/benthos/v4 v4.0.0-20250911163055-af824a0c7e26 h1:Q56IbfT
 github.com/DIMO-Network/benthos/v4 v4.0.0-20250911163055-af824a0c7e26/go.mod h1:NQBR+ek5JR3QICSV9S3UNcj9z/0Mww2+/1JkKt/3Ino=
 github.com/DIMO-Network/clickhouse-infra v0.0.8 h1:54HPXKvNjmn9T0d9ZLYgUm4DnwTavE+Z8admrf39mJI=
 github.com/DIMO-Network/clickhouse-infra v0.0.8/go.mod h1:XS80lhSJNWBWGgZ+m4j7++zFj1wAXfmtV2gJfhGlabQ=
-github.com/DIMO-Network/cloudevent v0.2.9-0.20260429154543-207c0df87d44 h1:lzpO98VaF/0zIXW0nk4+PWShPTXCmxJlvGUBUo1gnhQ=
-github.com/DIMO-Network/cloudevent v0.2.9-0.20260429154543-207c0df87d44/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
+github.com/DIMO-Network/cloudevent v0.2.9 h1:8MxbZtNReMHbwPUGQc2+G5THf08dFxju+npKZFZygJc=
+github.com/DIMO-Network/cloudevent v0.2.9/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
 github.com/DIMO-Network/model-garage v1.0.11 h1:aLvIyeo58p9pVgz+d3DnU5k5Fxvxh6mq/jE2s3LxXoc=
 github.com/DIMO-Network/model-garage v1.0.11/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
 github.com/DIMO-Network/shared v1.0.7 h1:LfSgsqJ6R7EUyfo2GTfuhrCpoDcweJqe7eVOa4j7Xbo=

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/DIMO-Network/benthos/v4 v4.0.0-20250911163055-af824a0c7e26 h1:Q56IbfT
 github.com/DIMO-Network/benthos/v4 v4.0.0-20250911163055-af824a0c7e26/go.mod h1:NQBR+ek5JR3QICSV9S3UNcj9z/0Mww2+/1JkKt/3Ino=
 github.com/DIMO-Network/clickhouse-infra v0.0.8 h1:54HPXKvNjmn9T0d9ZLYgUm4DnwTavE+Z8admrf39mJI=
 github.com/DIMO-Network/clickhouse-infra v0.0.8/go.mod h1:XS80lhSJNWBWGgZ+m4j7++zFj1wAXfmtV2gJfhGlabQ=
-github.com/DIMO-Network/cloudevent v0.2.8 h1:Q0xGQVPlOshF2LSX/m15Qzi2n4BI0EQDgOM71gEbNsY=
-github.com/DIMO-Network/cloudevent v0.2.8/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
+github.com/DIMO-Network/cloudevent v0.2.9-0.20260429154543-207c0df87d44 h1:lzpO98VaF/0zIXW0nk4+PWShPTXCmxJlvGUBUo1gnhQ=
+github.com/DIMO-Network/cloudevent v0.2.9-0.20260429154543-207c0df87d44/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
 github.com/DIMO-Network/model-garage v1.0.11 h1:aLvIyeo58p9pVgz+d3DnU5k5Fxvxh6mq/jE2s3LxXoc=
 github.com/DIMO-Network/model-garage v1.0.11/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
 github.com/DIMO-Network/shared v1.0.7 h1:LfSgsqJ6R7EUyfo2GTfuhrCpoDcweJqe7eVOa4j7Xbo=

--- a/internal/processors/cloudeventconvert/attesation_msg.go
+++ b/internal/processors/cloudeventconvert/attesation_msg.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DIMO-Network/cloudevent"
 	"github.com/DIMO-Network/dis/internal/processors"
+	"github.com/DIMO-Network/dis/internal/processors/rawparquet"
 	"github.com/DIMO-Network/dis/internal/web3"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -16,6 +17,11 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/segmentio/ksuid"
 )
+
+// MaxTombstoneReasonBytes caps the length of the reason field in a tombstone
+// data payload. Tombstones are tiny by design and live alongside attestations
+// in ClickHouse; bounding reason keeps row size predictable and limits abuse.
+const MaxTombstoneReasonBytes = 512
 
 // processAttestationMsg is the entrypoint for attestation messages.
 // It validates the message, verifies the signature, and sets the metadata.
@@ -37,6 +43,15 @@ func (c *cloudeventProcessor) processAttestationMsg(ctx context.Context, msg *se
 		return service.MessageBatch{msg}
 	}
 
+	if event.Type == cloudevent.TypeAttestationTombstone {
+		voidsID, err := parseTombstoneData(event.Data)
+		if err != nil {
+			processors.SetError(msg, processorName, "invalid tombstone payload", err)
+			return service.MessageBatch{msg}
+		}
+		msg.MetaSetMut(rawparquet.MetaVoidsID, voidsID)
+	}
+
 	msg.MetaDelete("Authorization")
 	setMetaData(&event.CloudEventHeader, msg)
 	msg.MetaSetMut(processors.MessageContentKey, cloudEventValidContentType)
@@ -44,6 +59,34 @@ func (c *cloudeventProcessor) processAttestationMsg(ctx context.Context, msg *se
 	msg.SetStructuredMut(event)
 
 	return service.MessageBatch{msg}
+}
+
+// tombstoneData is the expected shape of a dimo.tombstone event's data payload.
+type tombstoneData struct {
+	VoidsID string `json:"voidsId"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// parseTombstoneData parses and validates a tombstone's data payload.
+// It returns the target attestation id (the value of voidsId).
+func parseTombstoneData(data json.RawMessage) (string, error) {
+	if len(data) == 0 {
+		return "", errors.New("data payload is required for tombstones")
+	}
+	var td tombstoneData
+	if err := json.Unmarshal(data, &td); err != nil {
+		return "", fmt.Errorf("data payload is not a tombstone object: %w", err)
+	}
+	if td.VoidsID == "" {
+		return "", errors.New("voidsId is required and must be non-empty")
+	}
+	if !ValidIdentifier(td.VoidsID) {
+		return "", fmt.Errorf("invalid voidsId: %s", td.VoidsID)
+	}
+	if len(td.Reason) > MaxTombstoneReasonBytes {
+		return "", fmt.Errorf("reason length %d exceeds max %d", len(td.Reason), MaxTombstoneReasonBytes)
+	}
+	return td.VoidsID, nil
 }
 
 // parseAndValidateAttestation unmarshals an attestation cloud event and
@@ -90,7 +133,7 @@ func parseAndValidateAttestation(msgBytes []byte, source string) (*cloudevent.Ra
 		event.Type = cloudevent.TypeAttestation
 	}
 	if !isValidAttestationType(event.Type) {
-		return nil, fmt.Errorf("invalid attestation type %q: must be dimo.attestation, dimo.raw.*, or dimo.document.*", event.Type)
+		return nil, fmt.Errorf("invalid attestation type %q: must be dimo.attestation, dimo.tombstone, dimo.raw.*, or dimo.document.*", event.Type)
 	}
 	return &event, nil
 }
@@ -98,6 +141,8 @@ func parseAndValidateAttestation(msgBytes []byte, source string) (*cloudevent.Ra
 func isValidAttestationType(t string) bool {
 	switch {
 	case t == cloudevent.TypeAttestation:
+		return true
+	case t == cloudevent.TypeAttestationTombstone:
 		return true
 	case strings.HasPrefix(t, "dimo.raw.") && len(t) > len("dimo.raw."):
 		return true

--- a/internal/processors/cloudeventconvert/cloudeventconvert_test.go
+++ b/internal/processors/cloudeventconvert/cloudeventconvert_test.go
@@ -12,8 +12,11 @@ import (
 	"github.com/DIMO-Network/cloudevent"
 	"github.com/DIMO-Network/dis/internal/processors"
 	"github.com/DIMO-Network/dis/internal/processors/httpinputserver"
+	"github.com/DIMO-Network/dis/internal/processors/rawparquet"
 	"github.com/DIMO-Network/model-garage/pkg/modules"
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/redpanda-data/benthos/v4/public/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -591,4 +594,216 @@ func TestParseAndValidateAttestationContentType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsValidAttestationType(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		cloudevent.TypeAttestation,
+		cloudevent.TypeAttestationTombstone,
+		"dimo.raw.insurance",
+		"dimo.document.vehicle.registration",
+	}
+	for _, ty := range valid {
+		assert.True(t, isValidAttestationType(ty), "expected %q to be valid", ty)
+	}
+
+	invalid := []string{
+		"",
+		"dimo.raw.",
+		"dimo.document.",
+		"dimo.signals",
+		"dimo.status",
+		"random",
+	}
+	for _, ty := range invalid {
+		assert.False(t, isValidAttestationType(ty), "expected %q to be invalid", ty)
+	}
+}
+
+func TestParseTombstoneData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		data            string
+		expectVoidsID   string
+		expectErr       bool
+		expectErrSubstr string
+	}{
+		{
+			name:          "valid tombstone",
+			data:          `{"voidsId":"target-id-1","reason":"uploaded by mistake"}`,
+			expectVoidsID: "target-id-1",
+		},
+		{
+			name:          "valid tombstone without reason",
+			data:          `{"voidsId":"target-id-1"}`,
+			expectVoidsID: "target-id-1",
+		},
+		{
+			name:            "empty data",
+			data:            ``,
+			expectErr:       true,
+			expectErrSubstr: "data payload is required",
+		},
+		{
+			name:            "data is not an object",
+			data:            `"just a string"`,
+			expectErr:       true,
+			expectErrSubstr: "not a tombstone object",
+		},
+		{
+			name:            "missing voidsId",
+			data:            `{"reason":"oops"}`,
+			expectErr:       true,
+			expectErrSubstr: "voidsId is required",
+		},
+		{
+			name:            "empty voidsId",
+			data:            `{"voidsId":"","reason":"oops"}`,
+			expectErr:       true,
+			expectErrSubstr: "voidsId is required",
+		},
+		{
+			name:            "voidsId with disallowed character",
+			data:            `{"voidsId":"bad id$"}`,
+			expectErr:       true,
+			expectErrSubstr: "invalid voidsId",
+		},
+		{
+			name:            "reason exceeds cap",
+			data:            fmt.Sprintf(`{"voidsId":"target-id-1","reason":"%s"}`, strings.Repeat("a", MaxTombstoneReasonBytes+1)),
+			expectErr:       true,
+			expectErrSubstr: "reason length",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			voidsID, err := parseTombstoneData(json.RawMessage(tt.data))
+			if tt.expectErr {
+				require.Error(t, err)
+				if tt.expectErrSubstr != "" {
+					assert.Contains(t, err.Error(), tt.expectErrSubstr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectVoidsID, voidsID)
+		})
+	}
+}
+
+// signTombstoneEvent builds a signed dimo.tombstone CloudEvent JSON using
+// the provided ECDSA key. The returned bytes match the wire format that DIS
+// would receive over the attestation endpoint, with a real EOA signature
+// over the data field.
+func signTombstoneEvent(t *testing.T, key string, source common.Address, subject, id, voidsID, reason string, ts time.Time) []byte {
+	t.Helper()
+	privKey, err := crypto.HexToECDSA(key)
+	require.NoError(t, err)
+
+	dataObj := map[string]string{"voidsId": voidsID}
+	if reason != "" {
+		dataObj["reason"] = reason
+	}
+	dataBytes, err := json.Marshal(dataObj)
+	require.NoError(t, err)
+
+	hash := accounts.TextHash(dataBytes)
+	sig, err := crypto.Sign(hash, privKey)
+	require.NoError(t, err)
+	// crypto.Sign returns v as 0/1; convert to Ethereum's 27/28.
+	sig[64] += 27
+
+	envelope := map[string]any{
+		"id":          id,
+		"source":      source.Hex(),
+		"producer":    source.Hex(),
+		"specversion": "1.0",
+		"subject":     subject,
+		"time":        ts.Format(time.RFC3339),
+		"type":        cloudevent.TypeAttestationTombstone,
+		"signature":   "0x" + common.Bytes2Hex(sig),
+		"data":        json.RawMessage(dataBytes),
+	}
+	out, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return out
+}
+
+func TestProcessAttestationMsg_Tombstone(t *testing.T) {
+	t.Parallel()
+
+	// Deterministic test key so the test is reproducible.
+	const privHex = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+	privKey, err := crypto.HexToECDSA(privHex)
+	require.NoError(t, err)
+	source := crypto.PubkeyToAddress(privKey.PublicKey)
+
+	subject := "did:erc721:80002:0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8:1005"
+	now := time.Now().UTC().Truncate(time.Minute)
+
+	t.Run("valid tombstone is accepted and sets dimo_voids_id metadata", func(t *testing.T) {
+		input := signTombstoneEvent(t, privHex, source, subject, "tombstone-id-1", "target-attestation-id-1", "uploaded in error", now)
+
+		msg := service.NewMessage(input)
+		msg.MetaSet(httpinputserver.DIMOCloudEventSource, source.Hex())
+		msg.MetaSet(processors.MessageContentKey, httpinputserver.AttestationContent)
+
+		proc := &cloudeventProcessor{}
+		out := proc.processAttestationMsg(context.Background(), msg, input, source.Hex())
+		require.Len(t, out, 1)
+		require.Nil(t, out[0].GetError(), "unexpected error: %v", out[0].GetError())
+
+		voidsID, ok := out[0].MetaGetMut(rawparquet.MetaVoidsID)
+		require.True(t, ok, "expected dimo_voids_id metadata to be set")
+		assert.Equal(t, "target-attestation-id-1", voidsID)
+
+		typeMeta, _ := out[0].MetaGetMut(cloudEventTypeKey)
+		assert.Equal(t, cloudevent.TypeAttestationTombstone, typeMeta)
+
+		contentMeta, _ := out[0].MetaGetMut(processors.MessageContentKey)
+		assert.Equal(t, "dimo_valid_cloudevent", contentMeta)
+	})
+
+	t.Run("tombstone with empty voidsId in data is rejected", func(t *testing.T) {
+		// Manually craft a tombstone where voidsId is empty but the signature
+		// still recovers (we sign over the actual empty-voidsId data).
+		dataObj := map[string]string{"voidsId": "", "reason": "x"}
+		dataBytes, err := json.Marshal(dataObj)
+		require.NoError(t, err)
+		hash := accounts.TextHash(dataBytes)
+		sig, err := crypto.Sign(hash, privKey)
+		require.NoError(t, err)
+		sig[64] += 27
+		envelope := map[string]any{
+			"id":          "tombstone-id-2",
+			"source":      source.Hex(),
+			"producer":    source.Hex(),
+			"specversion": "1.0",
+			"subject":     subject,
+			"time":        now.Format(time.RFC3339),
+			"type":        cloudevent.TypeAttestationTombstone,
+			"signature":   "0x" + common.Bytes2Hex(sig),
+			"data":        json.RawMessage(dataBytes),
+		}
+		input, err := json.Marshal(envelope)
+		require.NoError(t, err)
+
+		msg := service.NewMessage(input)
+		msg.MetaSet(httpinputserver.DIMOCloudEventSource, source.Hex())
+		msg.MetaSet(processors.MessageContentKey, httpinputserver.AttestationContent)
+
+		proc := &cloudeventProcessor{}
+		out := proc.processAttestationMsg(context.Background(), msg, input, source.Hex())
+		require.Len(t, out, 1)
+		require.NotNil(t, out[0].GetError(), "expected error for empty voidsId")
+	})
+
+	// Bad-signature behavior is identical for all attestation flavors and is
+	// covered by the existing TestProcessBatch cases for `dimo.attestation`;
+	// no need to duplicate it here.
 }

--- a/internal/processors/rawparquet/rawparquet.go
+++ b/internal/processors/rawparquet/rawparquet.go
@@ -31,6 +31,11 @@ const (
 	// row's data_index_key column. The splitter sets this on stripped events;
 	// inline events leave it unset.
 	MetaDataIndexKey = "dimo_data_index_key"
+	// MetaVoidsID, when present on an inbound CE message, is the id of the
+	// attestation that this event tombstones. It is server-extracted from
+	// the validated dimo.tombstone payload and ends up in the ClickHouse
+	// voids_id column. Empty/absent for non-tombstone events.
+	MetaVoidsID = "dimo_voids_id"
 	// MetaParquetPath is the object key (path) for downstream use.
 	MetaParquetPath  = "dimo_parquet_path"
 	MetaParquetSize  = "dimo_parquet_size"
@@ -99,7 +104,8 @@ func (p *processor) ProcessBatch(_ context.Context, msgs service.MessageBatch) (
 			continue
 		}
 		dataKey, _ := msg.MetaGet(MetaDataIndexKey)
-		good = append(good, cloudevent.StoredEvent{RawEvent: ev, DataIndexKey: dataKey})
+		voidsID, _ := msg.MetaGet(MetaVoidsID)
+		good = append(good, cloudevent.StoredEvent{RawEvent: ev, DataIndexKey: dataKey, VoidsID: voidsID})
 	}
 
 	if len(good) == 0 {
@@ -155,6 +161,7 @@ func (p *processor) ProcessBatch(_ context.Context, msgs service.MessageBatch) (
 		chRow := cloudevent.StoredEvent{
 			RawEvent:     g.RawEvent,
 			DataIndexKey: parquetEvents[parquetIdx[i]].DataIndexKey,
+			VoidsID:      g.VoidsID,
 		}
 		chMsg := service.NewMessage(nil)
 		row := clickhouse.StoredEventToSlice(&chRow, indexKeyMap[parquetIdx[i]])

--- a/internal/processors/rawparquet/rawparquet_test.go
+++ b/internal/processors/rawparquet/rawparquet_test.go
@@ -50,14 +50,23 @@ func newTestProcessor() *processor {
 	}
 }
 
+// Column order matches cloudevent/clickhouse.InsertStmt:
+// 0:subject, 1:time, 2:type, 3:id, 4:source, 5:producer,
+// 6:data_content_type, 7:data_version, 8:extras,
+// 9:index_key, 10:data_index_key, 11:voids_id.
+const (
+	chColIndexKey     = 9
+	chColDataIndexKey = 10
+	chColVoidsID      = 11
+)
+
 // chRowKey returns the index_key column from a ClickHouse row message.
-// Column order is ..., index_key, data_index_key — index_key is second-to-last.
 func chRowKey(t *testing.T, msg *service.Message) string {
 	t.Helper()
 	val, err := msg.AsStructured()
 	require.NoError(t, err)
 	row := val.([]any)
-	return row[len(row)-2].(string)
+	return row[chColIndexKey].(string)
 }
 
 // chRowDataKey returns the data_index_key column from a ClickHouse row message.
@@ -66,7 +75,16 @@ func chRowDataKey(t *testing.T, msg *service.Message) string {
 	val, err := msg.AsStructured()
 	require.NoError(t, err)
 	row := val.([]any)
-	return row[len(row)-1].(string)
+	return row[chColDataIndexKey].(string)
+}
+
+// chRowVoidsID returns the voids_id column from a ClickHouse row message.
+func chRowVoidsID(t *testing.T, msg *service.Message) string {
+	t.Helper()
+	val, err := msg.AsStructured()
+	require.NoError(t, err)
+	row := val.([]any)
+	return row[chColVoidsID].(string)
 }
 
 // chRowType returns the type column from a ClickHouse row message. Column
@@ -287,6 +305,40 @@ func TestProcessBatch_DataIndexKeyFromMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "cloudevent/blobs/some/key", events[0].DataIndexKey)
+}
+
+func TestProcessBatch_VoidsIDFromMetadata(t *testing.T) {
+	t.Parallel()
+	proc := newTestProcessor()
+
+	subject := "did:erc721:1:0xV:1"
+	msg := makeRawEventMsgWithType(t, "tombstone-row-1", subject, "dimo.tombstone")
+	msg.MetaSetMut(MetaVoidsID, "target-attestation-id-1")
+
+	result, err := proc.ProcessBatch(context.Background(), service.MessageBatch{msg})
+	require.NoError(t, err)
+	batch := result[0]
+	require.Len(t, batch, 2)
+
+	// The CH row should carry the voids_id from metadata, with data_index_key empty.
+	assert.Equal(t, "target-attestation-id-1", chRowVoidsID(t, batch[1]))
+	assert.Equal(t, "", chRowDataKey(t, batch[1]))
+}
+
+func TestProcessBatch_NoVoidsIDMetaIsEmpty(t *testing.T) {
+	t.Parallel()
+	proc := newTestProcessor()
+
+	msgs := service.MessageBatch{
+		makeRawEventMsg(t, "regular-event", "did:erc721:1:0xV:1"),
+	}
+
+	result, err := proc.ProcessBatch(context.Background(), msgs)
+	require.NoError(t, err)
+	batch := result[0]
+	require.Len(t, batch, 2)
+
+	assert.Equal(t, "", chRowVoidsID(t, batch[1]))
 }
 
 func TestProcessBatch_NoDataIndexKeyMetaIsEmpty(t *testing.T) {

--- a/tests/integration/assert_test.go
+++ b/tests/integration/assert_test.go
@@ -189,6 +189,7 @@ type CloudEventRow struct {
 	DataVersion     string    `db:"data_version"`
 	IndexKey        string    `db:"index_key"`
 	DataIndexKey    string    `db:"data_index_key"`
+	VoidsID         string    `db:"voids_id"`
 }
 
 // queryCloudEvents queries the ClickHouse cloud_event table for a given subject.
@@ -203,7 +204,7 @@ func queryCloudEvents(t *testing.T, subject string) []CloudEventRow {
 	require.NoError(t, err)
 
 	rows, err := indexDB.Query(
-		"SELECT subject, event_time, event_type, id, source, producer, data_content_type, data_version, index_key, data_index_key FROM cloud_event WHERE subject = ? ORDER BY event_type",
+		"SELECT subject, event_time, event_type, id, source, producer, data_content_type, data_version, index_key, data_index_key, voids_id FROM cloud_event WHERE subject = ? ORDER BY event_type",
 		subject,
 	)
 	require.NoError(t, err)
@@ -212,7 +213,7 @@ func queryCloudEvents(t *testing.T, subject string) []CloudEventRow {
 	var result []CloudEventRow
 	for rows.Next() {
 		var r CloudEventRow
-		err := rows.Scan(&r.Subject, &r.EventTime, &r.EventType, &r.ID, &r.Source, &r.Producer, &r.DataContentType, &r.DataVersion, &r.IndexKey, &r.DataIndexKey)
+		err := rows.Scan(&r.Subject, &r.EventTime, &r.EventType, &r.ID, &r.Source, &r.Producer, &r.DataContentType, &r.DataVersion, &r.IndexKey, &r.DataIndexKey, &r.VoidsID)
 		require.NoError(t, err)
 		result = append(result, r)
 	}
@@ -220,8 +221,8 @@ func queryCloudEvents(t *testing.T, subject string) []CloudEventRow {
 
 	t.Logf("ClickHouse cloud_event: %d rows for subject=%s", len(result), subject)
 	for i, r := range result {
-		t.Logf("  cloud_event[%d]: subject=%s eventType=%s eventTime=%v id=%s source=%s producer=%s dataContentType=%s dataVersion=%s indexKey=%s dataIndexKey=%s",
-			i, r.Subject, r.EventType, r.EventTime, r.ID, r.Source, r.Producer, r.DataContentType, r.DataVersion, r.IndexKey, r.DataIndexKey)
+		t.Logf("  cloud_event[%d]: subject=%s eventType=%s eventTime=%v id=%s source=%s producer=%s dataContentType=%s dataVersion=%s indexKey=%s dataIndexKey=%s voidsId=%s",
+			i, r.Subject, r.EventType, r.EventTime, r.ID, r.Source, r.Producer, r.DataContentType, r.DataVersion, r.IndexKey, r.DataIndexKey, r.VoidsID)
 	}
 	return result
 }

--- a/tests/integration/dis_test.go
+++ b/tests/integration/dis_test.go
@@ -45,9 +45,21 @@ processor_resources:
   - label: "dimo_error_count"
     noop: {}
   - label: "dimo_bad_request_sync_response"
-    noop: {}
+    processors:
+      - label: "bad_request_response_mapping"
+        mapping: |
+          meta response_status = 400
+          root = metadata("response_message").or("Bad Request")
+      - label: "bad_request_sync_response"
+        sync_response: {}
   - label: "dimo_internal_error_sync_response"
-    noop: {}
+    processors:
+      - label: "internal_error_response_mapping"
+        mapping: |
+          meta response_status = 500
+          root  =  metadata("response_message").or("Internal Error: Please try again later")
+      - label: "internal_error_sync_response"
+        sync_response: {}
   - label: "dimo_provider_input_count"
     noop: {}
   - label: "handle_db_connection_error"

--- a/tests/integration/edge_case_test.go
+++ b/tests/integration/edge_case_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFutureTimestampSignalPruning(t *testing.T) {
+func TestFutureTimestampSignalRejected(t *testing.T) {
 	subject := "did:erc721:137:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:8001"
 
 	futureTime := time.Now().Add(1 * time.Hour).UTC().Format("2006-01-02T15:04:05.000Z")
@@ -44,15 +44,12 @@ func TestFutureTimestampSignalPruning(t *testing.T) {
 
 	resp := postMTLS(t, payloadBytes)
 	drainAndClose(t, resp)
-	require.Equal(t, 200, resp.StatusCode)
+	require.NotEqual(t, 200, resp.StatusCode, "future-timestamp signal should be rejected")
 
 	time.Sleep(750 * time.Millisecond)
 
-	// The CloudEvent is still processed but the signal should be pruned
-	// because its timestamp is 1 hour in the future (> 5 min threshold).
-	// After pruning, all signals are removed so no signal CE should be produced.
 	msgs := consumeKafka(t, "topic.device.signals", startOffset, 10*time.Second)
-	require.Empty(t, msgs, "no signal CE should be produced when all signals are pruned")
+	require.Empty(t, msgs, "no signal CE should be produced when the input is rejected")
 }
 
 func TestDuplicateSignalPruning(t *testing.T) {
@@ -111,7 +108,7 @@ func TestDuplicateSignalPruning(t *testing.T) {
 	require.InDelta(t, 107.0, rows[0].ValueNumber, 0.01)
 }
 
-func TestEmptySignalsArray(t *testing.T) {
+func TestEmptySignalsArrayRejected(t *testing.T) {
 	subject := "did:erc721:137:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:8003"
 
 	payload := map[string]any{
@@ -136,11 +133,10 @@ func TestEmptySignalsArray(t *testing.T) {
 
 	resp := postMTLS(t, payloadBytes)
 	drainAndClose(t, resp)
-	require.Equal(t, 200, resp.StatusCode)
+	require.NotEqual(t, 200, resp.StatusCode, "empty signals array should be rejected")
 
 	time.Sleep(750 * time.Millisecond)
 
-	// No signal CE should be produced for an empty signals array
 	msgs := consumeKafka(t, "topic.device.signals", startOffset, 10*time.Second)
 	require.Empty(t, msgs, "no signal CE should be produced for empty signals array")
 }

--- a/tests/integration/tombstone_test.go
+++ b/tests/integration/tombstone_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTombstoneEndpoint posts an attestation, then a tombstone that voids it,
+// and asserts both rows exist in ClickHouse with the tombstone row's voids_id
+// pointing at the attestation's id.
+func TestTombstoneEndpoint(t *testing.T) {
+	clearMinIOObjects(t, "cloudevent/valid/")
+
+	subject := "did:erc721:137:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:556"
+	clearClickHouseForSubject(t, subject)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	ethAddr := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	// ── 1. Post an attestation ─────────────────────────────────────────
+	attestationData := map[string]any{
+		"subject":  subject,
+		"insured":  true,
+		"provider": "Test Insurance",
+	}
+	attDataBytes, err := json.Marshal(attestationData)
+	require.NoError(t, err)
+
+	attHash := accounts.TextHash(attDataBytes)
+	attSig, err := crypto.Sign(attHash, privateKey)
+	require.NoError(t, err)
+	attSig[64] += 27
+
+	const attestationID = "test-attestation-tombstone-target"
+	attPayload := map[string]any{
+		"id":          attestationID,
+		"subject":     subject,
+		"source":      ethAddr.Hex(),
+		"producer":    ethAddr.Hex(),
+		"specversion": "1.0",
+		"time":        time.Now().UTC().Format(time.RFC3339),
+		"type":        "dimo.attestation",
+		"signature":   "0x" + common.Bytes2Hex(attSig),
+		"data":        attestationData,
+	}
+	attBytes, err := json.Marshal(attPayload)
+	require.NoError(t, err)
+	t.Logf("Attestation payload: %s", string(attBytes))
+
+	resp := postJWTAttestation(t, attBytes, ethAddr)
+	drainAndClose(t, resp)
+	require.Equal(t, 200, resp.StatusCode, "attestation POST should return 200")
+
+	// ── 2. Post a tombstone for that attestation ────────────────────────
+	tombstoneData := map[string]string{
+		"voidsId": attestationID,
+		"reason":  "uploaded by mistake",
+	}
+	tdBytes, err := json.Marshal(tombstoneData)
+	require.NoError(t, err)
+
+	tdHash := accounts.TextHash(tdBytes)
+	tdSig, err := crypto.Sign(tdHash, privateKey)
+	require.NoError(t, err)
+	tdSig[64] += 27
+
+	const tombstoneID = "test-tombstone-001"
+	tdPayload := map[string]any{
+		"id":          tombstoneID,
+		"subject":     subject,
+		"source":      ethAddr.Hex(),
+		"producer":    ethAddr.Hex(),
+		"specversion": "1.0",
+		"time":        time.Now().UTC().Format(time.RFC3339),
+		"type":        "dimo.tombstone",
+		"signature":   "0x" + common.Bytes2Hex(tdSig),
+		"data":        tombstoneData,
+	}
+	tdPayloadBytes, err := json.Marshal(tdPayload)
+	require.NoError(t, err)
+	t.Logf("Tombstone payload: %s", string(tdPayloadBytes))
+
+	resp = postJWTAttestation(t, tdPayloadBytes, ethAddr)
+	drainAndClose(t, resp)
+	require.Equal(t, 200, resp.StatusCode, "tombstone POST should return 200")
+
+	// Wait for parquet batch flush + ClickHouse insert.
+	time.Sleep(2 * time.Second)
+
+	// ── 3. Both rows should exist in cloud_event ─────────────────────
+	rows := queryCloudEvents(t, subject)
+	require.Len(t, rows, 2, "expected attestation + tombstone rows")
+
+	var attRow, tdRow *CloudEventRow
+	for i := range rows {
+		switch rows[i].EventType {
+		case "dimo.attestation":
+			attRow = &rows[i]
+		case "dimo.tombstone":
+			tdRow = &rows[i]
+		}
+	}
+	require.NotNil(t, attRow, "attestation row missing")
+	require.NotNil(t, tdRow, "tombstone row missing")
+
+	require.Equal(t, attestationID, attRow.ID)
+	require.Empty(t, attRow.VoidsID, "non-tombstone events should have empty voids_id")
+
+	require.Equal(t, tombstoneID, tdRow.ID)
+	require.Equal(t, ethAddr.Hex(), tdRow.Source)
+	require.Equal(t, attestationID, tdRow.VoidsID, "tombstone voids_id should equal target attestation id")
+}
+
+// TestTombstoneEndpoint_RejectsEmptyVoidsID confirms a tombstone with an
+// empty voidsId in its data payload is rejected at the endpoint.
+func TestTombstoneEndpoint_RejectsEmptyVoidsID(t *testing.T) {
+	subject := "did:erc721:137:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:557"
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	ethAddr := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	tombstoneData := map[string]string{"voidsId": ""}
+	tdBytes, err := json.Marshal(tombstoneData)
+	require.NoError(t, err)
+
+	tdHash := accounts.TextHash(tdBytes)
+	tdSig, err := crypto.Sign(tdHash, privateKey)
+	require.NoError(t, err)
+	tdSig[64] += 27
+
+	tdPayload := map[string]any{
+		"id":          "test-tombstone-empty-target",
+		"subject":     subject,
+		"source":      ethAddr.Hex(),
+		"producer":    ethAddr.Hex(),
+		"specversion": "1.0",
+		"time":        time.Now().UTC().Format(time.RFC3339),
+		"type":        "dimo.tombstone",
+		"signature":   "0x" + common.Bytes2Hex(tdSig),
+		"data":        tombstoneData,
+	}
+	tdPayloadBytes, err := json.Marshal(tdPayload)
+	require.NoError(t, err)
+
+	resp := postJWTAttestation(t, tdPayloadBytes, ethAddr)
+	drainAndClose(t, resp)
+	require.NotEqual(t, 200, resp.StatusCode, "tombstone with empty voidsId should be rejected")
+}


### PR DESCRIPTION
This is our first attempt at supporting deletion. Developers send in attestations of the form

```ts
{
  "type": "dimo.tombstone",
  "source": "0xDC428E0F29a556f7403353E2c846ED169716F8Bc", // Developer license client id.
  "data": {
    "voidsId": "effd00b2-11bc-4d54-ae60-d6b830a82aee",
    "reason": "user_deleted" // Optional, no set enum.
```

These are respected "on read" by Fetch, which validates that the tombstone writer is the source for the document to be deleted.

As far as implementation: when the attestation endpoint receives a message of this type it sets the meta key `dimo_voids_id`. The Parquet writer uses this to populate the column.

Requires DIMO-Network/cloudevent#54.