### PR TITLE
Bump model-garage to v1.0.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,7 @@ GOOS_LIST := linux darwin
 GOARCH_LIST := amd64 arm64
 
 # Dependency versions
-# Pinned: 'latest' resolved to v2.12.2, whose tarball SHA256 doesn't match
-# the checksum baked into the upstream install script.
-GOLANGCI_VERSION   = v2.11.4
+GOLANGCI_VERSION   = latest
 MOCKGEN_VERSION    = $(shell go list -m -f '{{.Version}}' go.uber.org/mock)
 PROMETHEUS_VERSION = 2.47.0
 
@@ -108,7 +106,7 @@ tools-prometheus: ## Install Prometheus and promtool
 
 tools-golangci-lint:
 	@mkdir -p $(PATHINSTBIN)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PATHINSTBIN) $(GOLANGCI_VERSION)
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(PATHINSTBIN) $(GOLANGCI_VERSION)
 
 tools-mockgen: ## install mockgen tool
 	@mkdir -p $(PATHINSTBIN)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,9 @@ GOOS_LIST := linux darwin
 GOARCH_LIST := amd64 arm64
 
 # Dependency versions
-GOLANGCI_VERSION   = latest
+# Pinned: 'latest' resolved to v2.12.2, whose tarball SHA256 doesn't match
+# the checksum baked into the upstream install script.
+GOLANGCI_VERSION   = v2.11.4
 MOCKGEN_VERSION    = $(shell go list -m -f '{{.Version}}' go.uber.org/mock)
 PROMETHEUS_VERSION = 2.47.0
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/DIMO-Network/clickhouse-infra v0.0.8
 	github.com/DIMO-Network/cloudevent v0.2.11
-	github.com/DIMO-Network/model-garage v1.0.11
+	github.com/DIMO-Network/model-garage v1.0.12
 	github.com/DIMO-Network/shared v1.0.7
 	github.com/MicahParks/keyfunc/v3 v3.6.1
 	github.com/ethereum/go-ethereum v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/DIMO-Network/clickhouse-infra v0.0.8 h1:54HPXKvNjmn9T0d9ZLYgUm4DnwTav
 github.com/DIMO-Network/clickhouse-infra v0.0.8/go.mod h1:XS80lhSJNWBWGgZ+m4j7++zFj1wAXfmtV2gJfhGlabQ=
 github.com/DIMO-Network/cloudevent v0.2.11 h1:wcaMD1KafIzjwDyLLgFePeVyCWmTr+/0kK7lirJ6DmI=
 github.com/DIMO-Network/cloudevent v0.2.11/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
-github.com/DIMO-Network/model-garage v1.0.11 h1:aLvIyeo58p9pVgz+d3DnU5k5Fxvxh6mq/jE2s3LxXoc=
-github.com/DIMO-Network/model-garage v1.0.11/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
+github.com/DIMO-Network/model-garage v1.0.12 h1:42N/iwV7SHCyr2zmMpCa0HZRYXqNGomTECCTyxeO3Lo=
+github.com/DIMO-Network/model-garage v1.0.12/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
 github.com/DIMO-Network/shared v1.0.7 h1:LfSgsqJ6R7EUyfo2GTfuhrCpoDcweJqe7eVOa4j7Xbo=
 github.com/DIMO-Network/shared v1.0.7/go.mod h1:lDHUKwwT2LW6Zvd42Nb33dXklRNTmfyOlbUNx2dQfGY=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=


### PR DESCRIPTION
## Summary

- Bumps `github.com/DIMO-Network/model-garage` from v1.0.11 → v1.0.12.
- Picks up the Ruptela VIN decode fix from DIMO-Network/model-garage#261: `DecodeFingerprint` now trims **leading** padding (not just trailing), so PID 104 hex like `2020202020...` no longer leaves leading-space bytes that fail `vin.IsValidVIN()` / `vin.IsValidJapanChassis()` and cause the fingerprint to be silently dropped in `internal/processors/fingerprintvalidate`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/processors/fingerprintvalidate/...`
- Regression coverage for the trim behaviour lives in `model-garage`'s `convert_fingerprint_test.go` (added in #261).

https://claude.ai/code/session_01N6jjMS5NG9iRVCyKfSnHws

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6jjMS5NG9iRVCyKfSnHws)_