### PR TITLE
chore: bump model-garage to v1.0.13 (signal_latest + summary tables)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/DIMO-Network/clickhouse-infra v0.0.8
 	github.com/DIMO-Network/cloudevent v0.2.11
-	github.com/DIMO-Network/model-garage v1.0.12
+	github.com/DIMO-Network/model-garage v1.0.13
 	github.com/DIMO-Network/shared v1.0.7
 	github.com/MicahParks/keyfunc/v3 v3.6.1
 	github.com/ethereum/go-ethereum v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/DIMO-Network/clickhouse-infra v0.0.8 h1:54HPXKvNjmn9T0d9ZLYgUm4DnwTav
 github.com/DIMO-Network/clickhouse-infra v0.0.8/go.mod h1:XS80lhSJNWBWGgZ+m4j7++zFj1wAXfmtV2gJfhGlabQ=
 github.com/DIMO-Network/cloudevent v0.2.11 h1:wcaMD1KafIzjwDyLLgFePeVyCWmTr+/0kK7lirJ6DmI=
 github.com/DIMO-Network/cloudevent v0.2.11/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
-github.com/DIMO-Network/model-garage v1.0.12 h1:42N/iwV7SHCyr2zmMpCa0HZRYXqNGomTECCTyxeO3Lo=
-github.com/DIMO-Network/model-garage v1.0.12/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
+github.com/DIMO-Network/model-garage v1.0.13 h1:KwFJ/v6XETGNtiqmP7/FbW9eQTZFVbIpZ6gdHzGL+Rc=
+github.com/DIMO-Network/model-garage v1.0.13/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
 github.com/DIMO-Network/shared v1.0.7 h1:LfSgsqJ6R7EUyfo2GTfuhrCpoDcweJqe7eVOa4j7Xbo=
 github.com/DIMO-Network/shared v1.0.7/go.mod h1:lDHUKwwT2LW6Zvd42Nb33dXklRNTmfyOlbUNx2dQfGY=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=


### PR DESCRIPTION
Bumps model-garage v1.0.12 → v1.0.13 so the startup goose run applies migrations 00010 (signal_latest ReplacingMergeTree + 2 MVs) and 00011 (signal_summary/event_summary AggregatingMergeTree + MVs). Additive DDL only; the projection drop (00012) is gated in model-garage v1.0.14 and is NOT included.

Part of the signalsLatest p50 fix (projection fan-out → point lookups): DIMO-Network/model-garage#263, DIMO-Network/telemetry-api#298.

After deploy: verify 7 new tables/MVs exist and `signal_latest` row count grows with ingest, then operator backfill runs (SQL in migration comments).