### PR TITLE
chore: bump model-garage to v1.0.14 (drop latest projections)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/DIMO-Network/clickhouse-infra v0.0.8
 	github.com/DIMO-Network/cloudevent v0.2.11
-	github.com/DIMO-Network/model-garage v1.0.13
+	github.com/DIMO-Network/model-garage v1.0.14
 	github.com/DIMO-Network/shared v1.0.7
 	github.com/MicahParks/keyfunc/v3 v3.6.1
 	github.com/ethereum/go-ethereum v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/DIMO-Network/clickhouse-infra v0.0.8 h1:54HPXKvNjmn9T0d9ZLYgUm4DnwTav
 github.com/DIMO-Network/clickhouse-infra v0.0.8/go.mod h1:XS80lhSJNWBWGgZ+m4j7++zFj1wAXfmtV2gJfhGlabQ=
 github.com/DIMO-Network/cloudevent v0.2.11 h1:wcaMD1KafIzjwDyLLgFePeVyCWmTr+/0kK7lirJ6DmI=
 github.com/DIMO-Network/cloudevent v0.2.11/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
-github.com/DIMO-Network/model-garage v1.0.13 h1:KwFJ/v6XETGNtiqmP7/FbW9eQTZFVbIpZ6gdHzGL+Rc=
-github.com/DIMO-Network/model-garage v1.0.13/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
+github.com/DIMO-Network/model-garage v1.0.14 h1:d0GhD3louhO46lOsWyjLnZChyI/XtDxp3Mq3VnYm1Og=
+github.com/DIMO-Network/model-garage v1.0.14/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
 github.com/DIMO-Network/shared v1.0.7 h1:LfSgsqJ6R7EUyfo2GTfuhrCpoDcweJqe7eVOa4j7Xbo=
 github.com/DIMO-Network/shared v1.0.7/go.mod h1:lDHUKwwT2LW6Zvd42Nb33dXklRNTmfyOlbUNx2dQfGY=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=


### PR DESCRIPTION
Bumps model-garage v1.0.13 → v1.0.14 so the startup goose run applies migration **00012**: drops the per-part `signal_latest_by_subject_source_name` and `event_latest_by_subject_source_name` projections and resets `deduplicate_merge_projection_mode` on both tables.

These are superseded by `signal_latest` + `signal_summary`/`event_summary` (model-garage v1.0.13, deployed via dis v0.4.19). telemetry-api has served latest-state and summary queries from the new tables since v0.4.11 (2026-06-11).

**Gate cleared before this PR:** 24h+ soak, prod stable on telemetry-api 0.4.12, and `system.query_log` shows **0** projection-served queries in the trailing 24h — nothing falls back to a full-history scan when the projections drop.

Removes the permanent merge-time projection-rebuild tax (`deduplicate_merge_projection_mode = 'rebuild'` from migration 00009) across ~348 projection parts on the signal table.

Final step of the signalsLatest p50 fix: DIMO-Network/model-garage#263, DIMO-Network/model-garage#264, DIMO-Network/telemetry-api#298.